### PR TITLE
Show album art using CoverArtArchive API

### DIFF
--- a/Functions/Images/getAlbumArt.js
+++ b/Functions/Images/getAlbumArt.js
@@ -66,7 +66,7 @@ async function getAlbumArt(albumName, albumArtist) {
 async function getAlbumArtArchive(album, artist){
   let imageUrl = null;
   // Search string query
-  const query = querystring.escape(album+" AND artist:"+artist);
+  const query = querystring.escape(album+" AND artist:"+artist+" AND status:official");
 
   // Makes GET request to query the database for the album
   try{

--- a/Functions/Images/getAlbumArt.js
+++ b/Functions/Images/getAlbumArt.js
@@ -1,5 +1,7 @@
 import axios from 'axios';
+import querystring from "querystring";
 import { spotify } from "../../Storage/config.js";
+import { XMLParser } from "fast-xml-parser";
 
 // Spotify API endpoint for searching albums
 const url = "https://api.spotify.com/v1/search";
@@ -55,5 +57,54 @@ async function getAlbumArt(albumName, albumArtist) {
     return null;
   }
 }
+/**
+ * Retrieves the album cover art from coverartarchive.org based on the album name and artist.
+ * @param {string} album - The name of the album
+ * @param {string} artist - The artist of the album
+ * @returns {string|null} The URL of the album cover image if found, or null if not found or an error occurs.
+ */
+async function getAlbumArtArchive(album, artist){
+  let imageUrl = null;
+  // Search string query
+  const query = querystring.escape(album+" AND artist:"+artist);
 
-export {getAlbumArt};
+  // Makes GET request to query the database for the album
+  try{
+    let response = await axios.get("https://musicbrainz.org/ws/2/release?query="+query, {
+      headers: {
+        Accept: 'application/xml'
+      }
+    });
+
+    // Parses XML response
+    const parser = new XMLParser({
+      ignoreAttributes : false
+    });
+    const parsedData = parser.parse(response.data);
+
+    const releases = parsedData.metadata['release-list'].release;
+
+    // Loops through matches until finding album cover
+    if(releases){
+      for (let i = 0; i < releases.length; i++) {
+        const release = releases[i];
+        const mbid = release['@_id'];
+        try{
+          // Makes GET request to get album cover
+          // If GET completes breaks from the loop
+          response = await axios.get("https://coverartarchive.org/release/"+mbid);
+          imageUrl = response.data.images[0].image;
+          break;
+        }catch(err){
+          // Cover art not avalible
+        }
+      }
+    }
+  }catch(error){
+    console.log("Please report this issue to the VLC-RPC devs!");
+    console.log(error);
+  }
+  return imageUrl;
+}
+
+export {getAlbumArt, getAlbumArtArchive};

--- a/Functions/rpc-format.js
+++ b/Functions/rpc-format.js
@@ -1,9 +1,9 @@
 /**
  * Description: Decides what information to display based on the nature of the media (video, music, etc)
  */
+import { getAlbumArt, getAlbumArtArchive } from "./Images/getAlbumArt.js";
 import { iconNames, movieApiKey, useSpotify } from "../Storage/config.js";
 import { fetchMovieData } from "./Images/searchMovie.js";
-import { getAlbumArt, getAlbumArtArchive } from "./Images/getAlbumArt.js";
 import { searchShow } from "./Images/searchShow.js";
 
 /**

--- a/Functions/rpc-format.js
+++ b/Functions/rpc-format.js
@@ -3,7 +3,7 @@
  */
 import { iconNames, movieApiKey, useSpotify } from "../Storage/config.js";
 import { fetchMovieData } from "./Images/searchMovie.js";
-import { getAlbumArt } from "./Images/getAlbumArt.js";
+import { getAlbumArt, getAlbumArtArchive } from "./Images/getAlbumArt.js";
 import { searchShow } from "./Images/searchShow.js";
 
 /**
@@ -118,12 +118,18 @@ async function handleMusic(meta, state) {
     partyMax = parseInt(meta.track_total, 10);
   }
   // Try to get the album art for the music
-  if(useSpotify) {
-    const art = await getAlbumArt(meta.album, meta.artist);
-    if (art) {
+  if(meta.album && meta.artist){
+    let art = null;
+    if(useSpotify){
+      art = await getAlbumArt(meta.album, meta.artist);
+    }else{
+      art = await getAlbumArtArchive(meta.album, meta.artist);
+    }
+    if(art){
       image = art;
     }
-  } 
+  }
+
   return {details, state, partySize, partyMax, image};
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.3.6",
         "child-process": "^1.0.2",
         "discord-rpc": "^4.0.1",
+        "fast-xml-parser": "^4.4.1",
         "vlc.js": "^3.2.7"
       },
       "devDependencies": {
@@ -1570,6 +1571,27 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
+    "node_modules/fast-xml-parser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
@@ -2709,6 +2731,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "node_modules/supports-color": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "axios": "^1.3.6",
     "child-process": "^1.0.2",
     "discord-rpc": "^4.0.1",
+    "fast-xml-parser": "^4.4.1",
     "vlc.js": "^3.2.7"
   },
   "scripts": {


### PR DESCRIPTION
Retrieves the album cover of songs by querying [MusicBrainz](https://musicbrainz.org) and using the [CoverArtArchive API](https://musicbrainz.org/doc/Cover_Art_Archive/API). 

Only works if the album and cover exist on the MusicBrainz database, otherwise just shows the default icon. Does not query if spotify album art is enabled.

Adds dependency: [fast-xml-parser](https://www.npmjs.com/package/fast-xml-parser) 4.4.1 or greater (for parsing musicbrainz response)