### PR TITLE
Remove button (no longer supported)

### DIFF
--- a/Functions/rpc-format.js
+++ b/Functions/rpc-format.js
@@ -211,13 +211,7 @@ export async function format(status) {
     instance: true,
     endTimestamp: endTimestamp,
     partySize: partySize,
-    partyMax: partyMax,
-    buttons: [
-      {
-        label: "GitHub Repo",
-        url: "https://github.com/vlc-rpc/vlc-discord-rpc"
-      }
-    ]
+    partyMax: partyMax
   };
 }
 


### PR DESCRIPTION
Buttons no longer appear in statuses. The discord-rpc library has not had updates in a long time,  so this likely won't be fixed. 