### PR TITLE
Fix getAlbumArtArchive bug

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,6 +1,6 @@
 name: Lint Code
 
-on:
+on: 
   pull_request:
     branches: [main]
 

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+    contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/Functions/Images/getAlbumArt.js
+++ b/Functions/Images/getAlbumArt.js
@@ -104,7 +104,8 @@ async function getAlbumArtArchive(album, artist){
     const releases = parsedData.metadata['release-list'].release;
     
     if(releases){
-      if(releases.length){ // Multiple matches found
+      if(releases.length){
+        // Multiple matches found
         // Loops through matches until finding one with an album cover
         for (let i = 0; i < releases.length; i++) {
           const release = releases[i];
@@ -114,7 +115,8 @@ async function getAlbumArtArchive(album, artist){
             break;
           }
         }
-      }else{ //Single match found
+      }else{ 
+        //Single match found
         const mbid = releases['@_id'];
         imageUrl = fetchCover(mbid);
       }

--- a/Functions/Images/getAlbumArt.js
+++ b/Functions/Images/getAlbumArt.js
@@ -57,6 +57,25 @@ async function getAlbumArt(albumName, albumArtist) {
     return null;
   }
 }
+
+/***
+ *  Gets cover from coverartarchive.org by looking up the releases's mbid
+ * @param {string} mbid - The id of the release in the musicbrainz database
+ * @returns {string|null} - The URL of the release's cover image if found, or null if it does not exist or an error occurs.
+ * */ 
+async function fetchCover(mbid) {
+  try{
+    // Makes GET request to get album cover
+    // If GET completes breaks from the loop
+    const response = await axios.get("https://coverartarchive.org/release/"+mbid);
+    const imageUrl = response.data.images[0].image;
+    return imageUrl;
+  }catch(err){
+    // Cover art not avalible
+    return null;
+  }
+}
+
 /**
  * Retrieves the album cover art from coverartarchive.org based on the album name and artist.
  * @param {string} album - The name of the album
@@ -70,7 +89,7 @@ async function getAlbumArtArchive(album, artist){
 
   // Makes GET request to query the database for the album
   try{
-    let response = await axios.get("https://musicbrainz.org/ws/2/release?query="+query, {
+    const response = await axios.get("https://musicbrainz.org/ws/2/release?query="+query, {
       headers: {
         Accept: 'application/xml'
       }
@@ -83,21 +102,21 @@ async function getAlbumArtArchive(album, artist){
     const parsedData = parser.parse(response.data);
 
     const releases = parsedData.metadata['release-list'].release;
-
-    // Loops through matches until finding album cover
+    
     if(releases){
-      for (let i = 0; i < releases.length; i++) {
-        const release = releases[i];
-        const mbid = release['@_id'];
-        try{
-          // Makes GET request to get album cover
-          // If GET completes breaks from the loop
-          response = await axios.get("https://coverartarchive.org/release/"+mbid);
-          imageUrl = response.data.images[0].image;
-          break;
-        }catch(err){
-          // Cover art not avalible
+      if(releases.length){ // Multiple matches found
+        // Loops through matches until finding one with an album cover
+        for (let i = 0; i < releases.length; i++) {
+          const release = releases[i];
+          const mbid = release['@_id'];
+          imageUrl = fetchCover(mbid);
+          if(imageUrl){
+            break;
+          }
         }
+      }else{ //Single match found
+        const mbid = releases['@_id'];
+        imageUrl = fetchCover(mbid);
       }
     }
   }catch(error){


### PR DESCRIPTION
ixes a bug where, when querying for releases, if the response returns a single result, it would not search for its cover art.
This should make it so that it doesn't just ignore responses that contain a single result anymore.
