### PR TITLE
fix: Replace removeAfter with sleepTime in default config richPresenceSettings object

### DIFF
--- a/Storage/example_config.js
+++ b/Storage/example_config.js
@@ -16,7 +16,7 @@ const vlcPath = '';
 const richPresenseSettings = {
   id: '',
   updateInterval: 5000,
-  removeAfter: 5000
+  sleepTime: 5000
 };
 
 // Default icons. Change if you would like.


### PR DESCRIPTION
Hey, one more minor thing - and I hope I didn't miss anything:  

There is no instance of `removeAfter` in the code base. The prop `sleepTime` is referenced however but not included in the default `richPresenceSettings` object. I assume you renamed the prop at some point and forgot to update the default config?  

I was about to implement that feature when I came across the code snippet referencing `sleepTime`, so I quickly renamed it.

Sorry if I missed anything and my assumption might therefore be wrong.